### PR TITLE
Fix mobile responsive UI for about page stats section #170

### DIFF
--- a/frontend/about/about.css
+++ b/frontend/about/about.css
@@ -428,8 +428,29 @@ section {
   .hero-content h1 {
     font-size: 2rem;
   }
+  .hero-content p {
+    font-size: 1rem;
+    padding: 0 1rem;
+  }
   .stats-grid {
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+    padding: 0 1rem;
+  }
+  .stat-card {
+    padding: 1.5rem;
+  }
+  .stat-number {
+    font-size: 2.5rem;
+  }
+  .stat-label {
+    font-size: 0.95rem;
+  }
+  .section-header h2 {
+    font-size: 1.8rem;
+  }
+  .features-grid, .vision-mission-grid, .team-grid {
+    grid-template-columns: 1fr;
   }
   .timeline::before {
     left: 0;
@@ -440,5 +461,50 @@ section {
   }
   .timeline-dot {
     left: 0;
+  }
+  .floating-icons span {
+    font-size: 1.5rem;
+  }
+  .overview-content {
+    padding: 1.5rem;
+    font-size: 1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero-content h1 {
+    font-size: 1.6rem;
+  }
+  .hero-content p {
+    font-size: 0.9rem;
+    padding: 0 1rem;
+  }
+  .container {
+    padding: 0 15px;
+  }
+  .stat-number {
+    font-size: 2rem;
+  }
+  .section-header h2 {
+    font-size: 1.5rem;
+  }
+  .scroll-button {
+    padding: 8px 16px;
+    font-size: 0.9rem;
+  }
+  section {
+    padding: 3rem 0;
+  }
+  .feature-icon {
+    width: 60px;
+    height: 60px;
+    font-size: 1.7rem;
+  }
+  .feature-card h4 {
+    font-size: 1.1rem;
+  }
+  .team-image {
+    font-size: 3rem;
+    height: 200px;
   }
 }


### PR DESCRIPTION
## 🐛 Issue
Fixes #170 

## 📝 Description
Fixed mobile responsive layout issues in the about page where stats cards and other content were getting cut off or improperly displayed on mobile devices.

## 🔧 Changes Made
- **Stats Section**: Changed grid layout from 2 columns to single column on mobile
- **Responsive Breakpoints**: Added comprehensive media queries for 768px and 480px
- **Typography**: Adjusted font sizes for better readability on small screens
  - Hero title: 3rem → 2rem (tablet) → 1.6rem (mobile)
  - Stats numbers: 3rem → 2.5rem (tablet) → 2rem (mobile)
  - Section headers: 2.3rem → 1.8rem (tablet) → 1.5rem (mobile)
- **Spacing**: Added proper padding and margins to prevent content cutoff
- **Grid Layouts**: All feature, vision-mission, and team grids now display as single column on mobile
- **Timeline**: Adjusted to left-aligned layout on mobile devices
- **Icons & Images**: Scaled down appropriately for smaller screens

## 📱 Mobile Improvements
### Before:
- Stats cards were cut off on mobile
- Content overflowing on small screens
- Poor spacing and readability

### After:
- Clean single-column layout
- All content visible and properly spaced
- Improved readability with adjusted font sizes
- Better user experience on all mobile devices

## ✅ Testing Checklist
- [x] Tested on mobile devices (< 768px)
- [x] Tested on small phones (< 480px)
- [x] All stats cards display properly
- [x] No content cutoff issues
- [x] Smooth animations work on mobile
- [x] All sections are properly visible
- [x] Timeline displays correctly on mobile


## 🔗 Related Issues
Closes #170

## Screenshots
Before 
<img width="476" height="841" alt="image" src="https://github.com/user-attachments/assets/97653aee-722c-47e9-ab9b-c6ffa66d9962" />

After
<img width="486" height="830" alt="image" src="https://github.com/user-attachments/assets/df45370e-2e4c-4e2e-b7ef-a831baecf7a7" />

